### PR TITLE
Change reject arguments for error message and code on curl error

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,10 +161,14 @@ module.exports = function () {
                     resolve({statusCode, body, headers});
                 });
 
-                this.curl.on('error', () => {
+                this.curl.on('error', (message, code) => {
+
+                    let error = new Error(message);
+                    error.code = code;
+
                     this.curl.close();
                     this._reset();
-                    reject(arguments);
+                    reject(error);
                 });
                 this.curl.perform();
             } catch (e) {


### PR DESCRIPTION
Changing reject parameters from `arguments` to Error with curl error message and code to use it when catching the error on requests